### PR TITLE
Support for options for writeFile and friends

### DIFF
--- a/src/specialMethods/writeFile-appendFile.js
+++ b/src/specialMethods/writeFile-appendFile.js
@@ -10,30 +10,26 @@ export const writeFileSync = syncMethod( 'writeFileSync' );
 export const appendFileSync = syncMethod( 'appendFileSync' );
 
 function normaliseArguments ( args ) {
-	let i = args.length;
-	const data = args[ --i ];
+	args = Array.prototype.slice.call( args, 0 );
+	let opts = {};
 
-	let pathargs = new Array( i );
-
-	while ( i-- ) {
-		pathargs[i] = args[i];
+	if ( typeof args[ args.length - 1 ] === 'object' && Object.prototype.toString.call( args[ args.length - 1 ] ) !== '[object Buffer]' ) {
+		opts = args.pop();
 	}
 
-	const dest = resolvePath( pathargs );
-
-	return { dest, data };
+	return { opts, data: args.pop(), dest: resolvePath( args ) };
 }
 
 function asyncMethod ( methodName ) {
 	return function () {
-		const { dest, data } = normaliseArguments( arguments );
+		const { dest, data, opts } = normaliseArguments( arguments );
 
 		return new Promise( ( fulfil, reject ) => {
 			mkdirp( dirname( dest ), err => {
 				if ( err ) {
 					reject( err );
 				} else {
-					fs[ methodName ]( dest, data, err => {
+					fs[ methodName ]( dest, data, opts, err => {
 						if ( err ) {
 							reject( err );
 						} else {

--- a/test/index.js
+++ b/test/index.js
@@ -40,6 +40,19 @@ describe( 'sander', function () {
 		});
 	});
 
+	describe( 'writeFile', function () {
+		it( 'allows options to be provided', function () {
+			var buf = new Buffer( [ 32, 32, 192, 192, 32, 32 ] );
+			return sander.writeFile( 'output', 'dir', 'out.bin', buf, { encoding: null } ).then( function () {
+				return sander.readFile( 'output', 'dir', 'out.bin', { encoding: null } ).then( function (b) {
+					for ( var i = 0; i < b.length; i++ ) {
+						assert.equal( buf[i], b[i] );
+					}
+				});
+			});
+		});
+	});
+
 	describe( 'copydir', function () {
 		it( 'copies a directory', function () {
 			return sander.copydir( 'input', 'dir' ).to( 'output' ).then( function () {


### PR DESCRIPTION
I stumbled across this today when I wanted to write a binary file. It seems that the current version of sander doesn't actually support an options arg to `writeFile` (and friends), since it always assumes that the last arg is the data. This checks to see if the last arg is an object that isn't a buffer and if so, uses it as the options arg.

I don't know if this is the way you would prefer to handle it, but slicing the array and using pop seemed way easier than a manual loop or index checks and bounds.
