### PR TITLE
bump deps & remove gobble-babel, gobble-esperanto-bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,20 +6,19 @@
   "license": "MIT",
   "repository": "https://github.com/rich-harris/sander",
   "dependencies": {
-    "es6-promise": "^2.0.0",
-    "mkdirp": "^0.5.0",
-    "rimraf": "^2.2.8",
-    "graceful-fs": "^3.0.4"
+    "es6-promise": "^3.0.2",
+    "mkdirp": "^0.5.1",
+    "rimraf": "^2.4.3",
+    "graceful-fs": "^4.1.2"
   },
   "main": "dist/sander.cjs.js",
   "jsnext:main": "dist/sander.es6.js",
   "devDependencies": {
-    "buffer-crc32": "^0.2.3",
-    "gobble": "^0.9.2",
-    "gobble-babel": "^5.1.0",
-    "gobble-cli": "^0.4.1",
-    "gobble-esperanto-bundle": "^0.1.7",
-    "mocha": "^2.2.4"
+    "buffer-crc32": "^0.2.5",
+    "gobble": "^0.10.2",
+    "gobble-cli": "^0.6.0",
+    "gobble-rollup-babel": "^0.6.1",
+    "mocha": "^2.3.3"
   },
   "scripts": {
     "test": "mocha",

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "license": "MIT",
   "repository": "https://github.com/rich-harris/sander",
   "dependencies": {
-    "es6-promise": "^3.0.2",
+    "es6-promise": "^3.1.2",
     "mkdirp": "^0.5.1",
-    "rimraf": "^2.4.3",
-    "graceful-fs": "^4.1.2"
+    "rimraf": "^2.5.2",
+    "graceful-fs": "^4.1.3"
   },
   "main": "dist/sander.cjs.js",
   "jsnext:main": "dist/sander.es6.js",
@@ -18,7 +18,7 @@
     "gobble": "^0.10.2",
     "gobble-cli": "^0.6.0",
     "gobble-rollup-babel": "^0.6.1",
-    "mocha": "^2.3.3"
+    "mocha": "^2.4.5"
   },
   "scripts": {
     "test": "mocha",


### PR DESCRIPTION
I really like sander but it was pulling in graceful-fs 3.x

I also noticed that es6-promise has a new version too.

so I upgraded them all. I tested gobble and ractive (along with my own files) and there seems to be no problem.

I also took the liberty of removing gobble-babel, gobble-esperanto-bundle from the dev deps. they're unused. you also forgot to add gobble-rollup-babel too, so I added it (actually gobble added it for me. I just pressed 'y')

cheers
