### PR TITLE
Add `module` field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "graceful-fs": "^4.1.3"
   },
   "main": "dist/sander.cjs.js",
+  "module": "dist/sander.es.js",
   "jsnext:main": "dist/sander.es.js",
   "devDependencies": {
     "buffer-crc32": "^0.2.5",


### PR DESCRIPTION
I noticed that `degit` was using the CJS version. See the built file here: https://www.unpkg.com/browse/degit@2.8.0/dist/index-26d8486e.js#L13149 (warning, huge page)

I hope this solves it. Either way, the field needs to be updated.